### PR TITLE
global: lxml parsing

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -54,6 +54,7 @@ setup_requires = [
 ]
 
 install_requires = [
+    'lxml>=3.6.0',
     'six>=1.10.0',
 ]
 


### PR DESCRIPTION
* BETTER Uses `lxml` for parsing .csl files.

Signed-off-by: Alexander Ioannidis <a.ioannidis@cern.ch>