### PR TITLE
 travis: setup automatic updates and releases

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,6 +4,7 @@ __pycache__/
 
 # Idea software family
 .idea/
+.vscode/
 
 # C extensions
 *.so

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,11 +1,10 @@
 # -*- coding: utf-8 -*-
 #
 # This file is part of citeproc-py-styles.
-# Copyright (C) 2016-2018 CERN.
+# Copyright (C) 2016-2019 CERN.
 #
 # citeproc-py-styles is free software; you can redistribute it and/or modify it
 # under the terms of the MIT License; see LICENSE file for more details.
-
 notifications:
   email: false
 
@@ -17,13 +16,16 @@ cache:
   - pip
 
 env:
-  - REQUIREMENTS=lowest
-  - REQUIREMENTS=release
-  - REQUIREMENTS=devel
+  matrix:
+    - REQUIREMENTS=lowest
+    - REQUIREMENTS=release
+    - REQUIREMENTS=devel
+  global:
+    secure: hNxkvOdRXDoUCjlYBG/dXX60L/DpyxyituyX9p8dIvTuxcJ3MbJKh529RLEXkOhS12v/BvuKdJa5fjs6gcnuiV7klSF2eYP0eeGe2Hl510IFdnqKWuW9RA3vW9htVNsq2zMk0xCnVixN0pWcFGLsaExFH3Ptc+IeEMcQqAArAvVdeUHVoE87AgEQsB5mfZef7xelFVj+FGvAP/3arsJyPd+0EZKJnjX7E2xA0LEJPL3H6eWvHRh8N8jdCaPmqFovZi37/avG+VEQxc0ILgE5W/QjMbsf30aTvCfchSPv8hukcrA4rPALhtLQ3+cxsFrznLL6/CnCc6gfCmcmmn5ff3LLpWIBoUN0e6pDtnHjrxCqQT9tK0eKHXODTxdow/b6DCJBKOcf2XJDIXY5qt3+5QTyZ4+xzIyrRdfN9ULHoafKXahiXcGCJL43X5wocIX5nSCYcVmexBFUORsv0z4YTjsDnWor5N4l4vJ4wRV30nIZZJXE4wFheqeYCWLL5+oe3u3urTFTw5hN3CEHBGURrXqOwYsoHifNwplbn8SN3JAKnv+WkOLtEwT6pKwZLdWy4+l2mMX/8TFsgyXg4s4t8WKI9Yeop1DE5dWlN1uvhXZ9PdRK3cUYmMGbVjEDEy3zDZf+Icf8nMr3sHSPaqCVgDJmzJXYK81EV2l67uJ5ZCw=
 
 python:
-  - "2.7"
-  - "3.5"
+  - '2.7'
+  - '3.5'
 
 matrix:
   fast_finish: true
@@ -31,29 +33,48 @@ matrix:
     - env: REQUIREMENTS=devel
 
 before_install:
-  - "travis_retry pip install --upgrade pip setuptools py"
-  - "travis_retry pip install twine wheel coveralls requirements-builder"
-  - "requirements-builder --level=min setup.py > .travis-lowest-requirements.txt"
-  - "requirements-builder --level=pypi setup.py > .travis-release-requirements.txt"
-  - "requirements-builder --level=dev --req requirements-devel.txt setup.py > .travis-devel-requirements.txt"
+  - travis_retry pip install --upgrade pip setuptools py
+  - travis_retry pip install twine wheel coveralls requirements-builder
+  - requirements-builder --level=min setup.py > .travis-lowest-requirements.txt
+  - requirements-builder --level=pypi setup.py > .travis-release-requirements.txt
+  - requirements-builder --level=dev --req requirements-devel.txt setup.py > .travis-devel-requirements.txt
 
 install:
-  - "travis_retry pip install -r .travis-${REQUIREMENTS}-requirements.txt"
-  - "travis_retry pip install -e .[all]"
+  - travis_retry pip install -r .travis-${REQUIREMENTS}-requirements.txt
+  - travis_retry pip install -e .[all]
 
 script:
-  - "./run-tests.sh"
+  - ./run-tests.sh
 
 after_success:
-- coveralls
+  - coveralls
 
-deploy:
-  provider: pypi
-  user: inveniosoftware
-  password:
-    secure: "WHvRhQUacZVfzdLKS6IsFn4+5fZB8+80nyrFLZgg5OApEf0/i+RC6UsKZCbHKOjUsUgiZgCChp6ipjW4HIWXrHpFh+sa6nbrVAkiCWyT8P9abEZs7rTtJ0Md5pjliF1D5Qc/vHCmVHkcxFw3GbRsDRkToW4EeXZX108y6vUw+ROQpSg3u9JWIzyO8hSOXaowSkFjhY+8TciEGMLN0rcUo2HIVZkW5TlsgDPUyYmE2MlTGsx86lDkeL5e2KqkZ3mwQZvjCDKkYEGmVXZihCkwdyePUrYfc1+amWAdb2yPVFPiNkrJKtJiFnPaBLHLdIwI4rYKcPtmVPWML7NZijRRewGoL+edmk0Mv2KGfDRsBKkXeFlOiu7Kpb6sTUXJbxTOL3/0DoPNxFoiSvJxIoX925ZqnLKqwNEA6FRl0rPrWJQhBzVQtZbKkLX1lUxhRBf+aW5+F6KCBk46vr8Ky+WeDNvDjPqni7DrOdKRUYRrKGyLcwkjskGY3ljH/Gsw0/trMUl5IyqENvPHuAbCqr1vJ6+oIfAcFNoJLezSq1jSkDlpspDCOOVlDp/H3NcjqTd04WsG7V6vWop66TSdZcQRSL0vQWNufYyyWYS0DPg2LN/FGFGnRBcZSPIwdLL7nMlOTo8nyPw/FBcxmyUxUMt54v1McKVb/h5OITJosvRanYk="
-  distributions: "sdist bdist_wheel"
-  on:
-    tags: true
-    python: "2.7"
-    condition: $REQUIREMENTS = release
+stages:
+  - name: update
+    if: type = cron
+  - name: test
+    if: type != cron
+  - name: deploy
+    if: tag IS present
+
+jobs:
+  include:
+  - stage: update
+    python: '3.5'
+    env: REQUIREMENTS=release
+    before_script: ./run-update.sh
+    after_success:
+      - git remote add origin-travis https://${GH_TOKEN}@github.com/${TRAVIS_REPO_SLUG}
+      - git push origin-travis HEAD:$TRAVIS_BRANCH --follow-tags
+  - stage: deploy
+    python: '3.5'
+    env: REQUIREMENTS=release
+    deploy:
+      provider: pypi
+      user: inveniosoftware
+      password:
+        secure: WHvRhQUacZVfzdLKS6IsFn4+5fZB8+80nyrFLZgg5OApEf0/i+RC6UsKZCbHKOjUsUgiZgCChp6ipjW4HIWXrHpFh+sa6nbrVAkiCWyT8P9abEZs7rTtJ0Md5pjliF1D5Qc/vHCmVHkcxFw3GbRsDRkToW4EeXZX108y6vUw+ROQpSg3u9JWIzyO8hSOXaowSkFjhY+8TciEGMLN0rcUo2HIVZkW5TlsgDPUyYmE2MlTGsx86lDkeL5e2KqkZ3mwQZvjCDKkYEGmVXZihCkwdyePUrYfc1+amWAdb2yPVFPiNkrJKtJiFnPaBLHLdIwI4rYKcPtmVPWML7NZijRRewGoL+edmk0Mv2KGfDRsBKkXeFlOiu7Kpb6sTUXJbxTOL3/0DoPNxFoiSvJxIoX925ZqnLKqwNEA6FRl0rPrWJQhBzVQtZbKkLX1lUxhRBf+aW5+F6KCBk46vr8Ky+WeDNvDjPqni7DrOdKRUYRrKGyLcwkjskGY3ljH/Gsw0/trMUl5IyqENvPHuAbCqr1vJ6+oIfAcFNoJLezSq1jSkDlpspDCOOVlDp/H3NcjqTd04WsG7V6vWop66TSdZcQRSL0vQWNufYyyWYS0DPg2LN/FGFGnRBcZSPIwdLL7nMlOTo8nyPw/FBcxmyUxUMt54v1McKVb/h5OITJosvRanYk=
+      distributions: sdist bdist_wheel
+      on:
+        tags: true
+        repo: inveniosoftware/citeproc-py-styles

--- a/run-update.sh
+++ b/run-update.sh
@@ -1,0 +1,55 @@
+#!/usr/bin/env sh
+# -*- coding: utf-8 -*-
+#
+# This file is part of citeproc-py-styles.
+# Copyright (C) 2019 CERN.
+#
+# citeproc-py-styles is free software; you can redistribute it and/or modify it
+# under the terms of the MIT License; see LICENSE file for more details.
+#
+# Update the git submodule. If there are updates, create and tag a new release.
+set -e
+
+# Setup the Git credentials for committing and tagging as Invenio.
+setup_git () {
+    git config user.name "Invenio"
+    git config user.email "info@inveniosoftware.org"
+}
+
+# Commit changes in the git submodule.
+commit_changes () {
+    git add citeproc_styles/version.py
+    git commit -am "data: update the CSL styles in build $TRAVIS_BUILD_NUMBER"
+}
+
+# Create a new version by changing the version number
+# and creating a tagged commit.
+tag_release () {
+    sed -i "s/__version__ =.*/__version__ = '$VERSION'/" citeproc_styles/version.py
+    git add citeproc_styles/version.py
+    git commit -m "release: $VERSION"
+    git tag -a $TAG -m "release: citeproc_py_styles $VERSION"
+}
+
+# In case we run the script locally we have to set the build number.
+if [ -z "$TRAVIS_BUILD_NUMBER" ]; then TRAVIS_BUILD_NUMBER="local"; fi
+
+# Update the git submodule to add upstream changes. If there are changes
+# we prepare a new release by commiting the upstream changes and tagging
+# a new release using a YYYY.MM.DD schema.
+git submodule update --remote --merge
+VERSION="$(date +'%Y.%m.%d')"
+TAG="v$VERSION"
+if [ -z "$(git diff --name-only)" ]
+then
+    echo "No changes found."
+elif [ "$(git tag list $TAG)" ]
+then
+    echo "Tag $TAG already exists"
+    exit 1
+else
+    echo "Changes found. Commiting and tagging $VERSION."
+    setup_git
+    commit_changes
+    tag_release
+fi


### PR DESCRIPTION
Update the Travis file to add cron triggered updates and releases of citeproc-py-styles. For this, we added run-update.sh and an update stage to Travis.

run-update.sh triggers a git submodule update for the CSL Style repository. If there are changes in this repository we commit these changes and create a tagged commit with a new release. To have simple and reliable versioning we switch away from semantic versioning to date
versioning.

The Travis file is changed to distinguish three different situations:
1. Regular build
2. Cron triggered build
3. Tagged build

For the regular builds, we don't change a lot. We added python 3.6 support, this in line with other Invenio modules. As a result, this build triggers the test for three different Python versions: 2.7, 3.5 and 3.6.

![normal-build](https://user-images.githubusercontent.com/7934339/62136223-f341b200-b2e3-11e9-9879-84ac199a3585.png)

The cron triggered builds are the new update builds. The cron triggered builds only run the update stage. This stage updates the submodule to the latest version and, if there are changes, tags a new release. After a simple test (just Python 3.6) these changes are pushed.

![release-train](https://user-images.githubusercontent.com/7934339/62136189-e1f8a580-b2e3-11e9-8c43-984f94d54632.png)

The tagged builds run two stages. The first stage is a regular build, testing the module for different Python versions. If this succeeds the release stage is triggered, this stage releases the new package to Pypi.

![tagged-build](https://user-images.githubusercontent.com/7934339/62136231-f76dcf80-b2e3-11e9-82c4-37136c7f42ec.png)

Closes #11