### PR TITLE
fix: replaced pkg_resources with importlib.resources

### DIFF
--- a/tests/test_csl.py
+++ b/tests/test_csl.py
@@ -14,7 +14,7 @@ import os
 
 import pytest
 
-from citeproc_styles import get_style_filepath, get_style_name
+from citeproc_styles import get_all_styles, get_style_filepath, get_style_name
 from citeproc_styles.errors import StyleNotFoundError
 
 
@@ -46,3 +46,9 @@ def test_style_name():
 
     with pytest.raises(StyleNotFoundError):
         name = get_style_name('non-existent-style')
+
+
+def test_list_all_styles():
+    """Test listing styles."""
+    styles = get_all_styles()
+    assert "Journal of Applied Animal Research" in styles.values()


### PR DESCRIPTION
### Description

Replaced pkg_resources calls with importlib_resources calls and added missing test for getting all styles.

### Checklist

Ticks in all boxes and 🟢 on all GitHub actions status checks are required to merge:

- [x] I'm aware of the [code of conduct](https://inveniordm.docs.cern.ch/contribute/code-of-conduct/).
- [x] I've created [logical separate commits](https://inveniordm.docs.cern.ch/develop/best-practices/commits/#commits) and followed the [commit message format](https://inveniordm.docs.cern.ch/develop/best-practices/commits/#commit-message).
- [x] I've added relevant test cases.
- [ ] I've added relevant documentation.
- [ ] I've marked [translation strings](https://inveniordm.docs.cern.ch/develop/howtos/i18n/).
- [ ] I've identified the [copyright holder(s)](https://inveniordm.docs.cern.ch/contribute/copyright-policy/) and updated copyright headers for touched files (>15 lines contributions).
- [x] I've NOT included third-party code (copy/pasted source code or new dependencies).
    * If you have added [third-party code (copy/pasted or new dependencies)](https://inveniordm.docs.cern.ch/develop/best-practices/commits/#third-party-codedependencies), please reach out to an [architect on Discord](https://discord.gg/8qatqBC).

**Frontend**

- [ ] I've followed the [CSS/JS](https://inveniordm.docs.cern.ch/develop/best-practices/css-js/) and [React](https://inveniordm.docs.cern.ch/develop/best-practices/react/) guidelines.
- [ ] I've followed the [web accessibility](https://inveniordm.docs.cern.ch/develop/best-practices/accessibility/) guidelines.
- [ ] I've followed the [user interface](https://inveniordm.docs.cern.ch/develop/best-practices/ui/) guidelines.


**Reminder**

By using GitHub, you have already agreed to the [GitHub’s Terms of Service](https://help.github.com/articles/github-terms-of-service/#6-contributions-under-repository-license) including that:

1. You license your contribution under the same terms as the current repository’s license.
2. You agree that you have the right to license your contribution under the current repository’s license.
